### PR TITLE
#9: Changed the behaviour of 'difference' flag

### DIFF
--- a/code/args/case/dnr_case_table.c
+++ b/code/args/case/dnr_case_table.c
@@ -30,6 +30,13 @@
 #include "../../util/dnr_util_conv.h"
 #include "../../util/dnr_util_fmt.h"
 
+/* !\ brief Cell type, according to format for the first cell */
+static enum dnr_nmod_list dnr_set_fnmod = DNR_NMOD_DEFAULT;
+/* !\ brief Cell type, according to format for middle cells */
+static enum dnr_nmod_list dnr_set_mnmod = DNR_NMOD_DEFAULT;
+/* !\ brief Cell type, according to format for the last cell */
+static enum dnr_nmod_list dnr_set_lnmod = DNR_NMOD_DEFAULT;
+
 /*! \brief Processes width of the table */
 static void _args_table_twidth(void) {
     if (!dnr_set_svalue(&dnr_set_twidth, optarg)) {
@@ -72,7 +79,18 @@ static void _args_table_tcount(void) {
 
 /*! \brief Processes difference flag */
 static void _args_table_diff(void) {
-    dnr_set_diff = true;
+    dnr_set_difference = true;
+}
+
+/*! \brief Checks the matching type of the format cells */
+static void _args_check_fmts(void) {
+    if (dnr_set_fnmod != dnr_set_mnmod ||
+        dnr_set_mnmod != dnr_set_lnmod) {
+        fprintf(stderr, "Printing types of all cells should match (%d %d %d)\n", dnr_set_fnmod, dnr_set_mnmod, dnr_set_lnmod);
+        dnr_util_help(EXIT_FAILURE);
+    }
+
+    dnr_set_mod = dnr_set_fnmod;
 }
 
 /*! \brief Processes arguments meant for table-related things
@@ -93,4 +111,9 @@ void dnr_args_table(int c) {
         case DNR_OPTC_TDFF : _args_table_diff();
                              break;
     }
+}
+
+/*! \brief Table arguments check */
+void dnr_args_checktable(void) {
+    _args_check_fmts();
 }

--- a/code/args/case/dnr_case_table.h
+++ b/code/args/case/dnr_case_table.h
@@ -26,4 +26,7 @@
  * \param[in] c Args-character */
 void dnr_args_table(int c);
 
+/*! \brief Table arguments check */
+void dnr_args_checktable(void);
+
 #endif

--- a/code/args/dnr_args_opts.h
+++ b/code/args/dnr_args_opts.h
@@ -127,14 +127,26 @@
 /*! \brief Char option for table's number of elements */
 #define DNR_OPTC_TCNT 's'
 
-/*! \brief Long option for flag writing only difference between steps 
- * instead of direct value
+/*! \brief Long option for "difference" mode.
+ * In this mode:
+ * - No actual values will be printed
+ * - Instead the difference between values is shown
  *
- * Ex.: [0, 5, 18, 14] will be [0, 5, 13, -4] */
+ * This mode is useful for the cases when one wants to move the object
+ * relatively and not by the absolute positioning. For instance when
+ * there is two objects on different starting positions but the movement
+ * should be the same.
+ * Ex.L [0, 5, 18, 14] will convert into [0, 5, 13, -4] 
+ *
+ * The main principce of the calculation of this mode is
+ * ~~~
+ * round(A[n]) - round(A[n-1])
+ * ~~~
+ * 'thanks to https://github.com/truebluepl user */
 #define DNR_OPTL_TDFF "difference"
-/*! \brief Short option for difference */
+/*! \brief Short option for diff mode */
 #define DNR_OPTS_TDFF "d"
-/*! \brief Char option for difference */
+/*! \brief Char option for diff mode */
 #define DNR_OPTC_TDFF 'd'
 
 #endif

--- a/code/args/dnr_args_process.c
+++ b/code/args/dnr_args_process.c
@@ -110,10 +110,10 @@ void dnr_args_process(int argc, char * argv[]) {
                                  break;
 
             case -1 :
+                dnr_args_checktable();
                 return;
 
             default :
-                fprintf(stderr, "Unknown option: %s\n", optarg);
                 dnr_util_help(EXIT_FAILURE);
         }
     }

--- a/code/args/dnr_args_vars.c
+++ b/code/args/dnr_args_vars.c
@@ -53,13 +53,9 @@ const char * dnr_set_fmcell = "%8.2f ";
 /*! \brief Printf-like formatting string for last cell rendering */
 const char * dnr_set_flcell = NULL;
 
-/* !\ brief Cell type, according to format for the first cell */
-enum dnr_nmod_list dnr_set_fnmod = DNR_NMOD_F64;
-/* !\ brief Cell type, according to format for middle cells */
-enum dnr_nmod_list dnr_set_mnmod = DNR_NMOD_F64;
-/* !\ brief Cell type, according to format for the last cell */
-enum dnr_nmod_list dnr_set_lnmod = DNR_NMOD_F64;
+/* !\ brief Cell type, according to format for cells */
+enum dnr_nmod_list dnr_set_mod = DNR_NMOD_DEFAULT;
 
 /*! \brief Difference between cells */
-bool dnr_set_diff = false;
+bool dnr_set_difference = false;
 

--- a/code/args/dnr_args_vars.h
+++ b/code/args/dnr_args_vars.h
@@ -63,14 +63,12 @@ extern const char * dnr_set_fmcell;
 /*! \brief Printf-like formatting string for last cell rendering */
 extern const char * dnr_set_flcell;
 
-/* !\ brief Cell type, according to format for the first cell */
-extern enum dnr_nmod_list dnr_set_fnmod;
-/* !\ brief Cell type, according to format for middle cells */
-extern enum dnr_nmod_list dnr_set_mnmod;
-/* !\ brief Cell type, according to format for the last cell */
-extern enum dnr_nmod_list dnr_set_lnmod;
+/*! \brief Default value for cell printing mode */
+#define DNR_NMOD_DEFAULT (DNR_NMOD_F64)
+/*! \brief Cell type, according to format for the first cell */
+extern enum dnr_nmod_list dnr_set_mod;
 
 /*! \brief Difference between cells */
-extern bool dnr_set_diff;
+extern bool dnr_set_difference;
 
 #endif

--- a/code/table/dnr_table_print.c
+++ b/code/table/dnr_table_print.c
@@ -30,20 +30,24 @@
 /*! \brief Prints the table values */
 void dnr_table_print(void) {
     for (size_t x = 0; x < dnr_set_tcount; x++) {
-        double fy = dnr_util_plot(dnr_set_tcount, (double)x, dnr_set_diff);
+        double fy = dnr_util_plot(
+            dnr_set_tcount, 
+            (double)x, 
+            dnr_set_difference
+        );
 
         if (x % dnr_set_twidth == 0) {
             if (dnr_set_ffcell)
-                 dnr_nmod_data[dnr_set_fnmod].func(dnr_set_ffcell, fy);
-            else dnr_nmod_data[dnr_set_mnmod].func(dnr_set_fmcell, fy);
+                 dnr_nmod_data[dnr_set_mod].func(dnr_set_ffcell, fy);
+            else dnr_nmod_data[dnr_set_mod].func(dnr_set_fmcell, fy);
 
         } else if (x % dnr_set_twidth == dnr_set_twidth - 1) {
             if (dnr_set_flcell)
-                 dnr_nmod_data[dnr_set_lnmod].func(dnr_set_flcell, fy);
-            else dnr_nmod_data[dnr_set_mnmod].func(dnr_set_fmcell, fy);
+                 dnr_nmod_data[dnr_set_mod].func(dnr_set_flcell, fy);
+            else dnr_nmod_data[dnr_set_mod].func(dnr_set_fmcell, fy);
 
         } else {
-            dnr_nmod_data[dnr_set_mnmod].func(dnr_set_fmcell, fy);
+            dnr_nmod_data[dnr_set_mod].func(dnr_set_fmcell, fy);
         }
 
         if (x % dnr_set_twidth == dnr_set_twidth - 1)

--- a/code/util/dnr_util_help.c
+++ b/code/util/dnr_util_help.c
@@ -27,6 +27,7 @@
 #include "../util/dnr_util_print.h"
 
 static const char * dnr_help_string[] = {
+    "\n"
     "DONER - Easing tables generator\n", 
     "HOW TO USE\n", 
     "\n", 
@@ -565,22 +566,6 @@ static const char * dnr_help_string[] = {
     "    .byte $03, $03, $04, $04\n",
     "    .byte $04, $04, $04, $04\n",
     "\n",
-    "   Note:\n",
-    "       Be advised, that in this mode the final point of the object could\n",
-    "       differ from the last value of the non-diff mode! That happens\n",
-    "       because of the cumulative rounding error. This cannot be solved\n",
-    "       easily in the code, as some side effects will present:\n",
-    "       * If to remove the `round` call - the 39.999 values will become 39\n",
-    "           instead of 40. Thus making final point wrong again\n",
-    "       * If to calc diff between printed values (not the original ones)\n",
-    "           then the ever-growing function will sometime produce decreasing\n",
-    "           values. Like in the example above:\n",
-    "\n",
-    "       00, 00, 01, 02, 03, 05, 08, 10\n",
-    "          0   1   1   1   2   3   2\n",
-    "\n",
-    "       So it is recommended to check the final point and correct some values\n",
-    "       manually (changing the 5th value in this case from 2 to 1 for ex.)\n"
 };
 
 /*! \brief Print help and exit 

--- a/code/util/dnr_util_plot.c
+++ b/code/util/dnr_util_plot.c
@@ -58,7 +58,11 @@ double dnr_util_plot(size_t width, double x, bool diff) {
     if (diff) {
         double pprev = prev;
         prev = fy;
-        fy -= pprev;
+
+        /* The float values don't need rounding while the integer values do */
+        if (dnr_set_mod == DNR_NMOD_F64)
+             fy =       fy  -       pprev;
+        else fy = round(fy) - round(pprev);
     }
 
     return fy;


### PR DESCRIPTION
Also removed unneeded wrong argument warning, requiring the same type when formatting first/middle/last cells